### PR TITLE
Don't log to Slack on 'info'

### DIFF
--- a/hammers/slack.py
+++ b/hammers/slack.py
@@ -33,6 +33,15 @@ class Slackbot(object):
         '''Newer version of ``post()`` that omits the script name'''
         return self.post(self.script_name, payload, color=color)
 
+    def success(self, payload):
+        return self.message(payload, color='xkcd:chartreuse')
+
+    def error(self, payload):
+        return self.message(payload, color='xkcd:red')
+
+    def exception(self):
+        return self.message(traceback.format_exc(), color='xkcd:red')
+
     def post(self, script, payload, color='#ccc'):
         if color.startswith('xkcd:'):
             color = colors.XKCD_COLORS[color[5:]]


### PR DESCRIPTION
This refactors all of the hammers to only log to Slack when it actually did something important. The information messages still get printed out to stdout.

This required refactoring business logic in most if not all of the hammers, because the info vs. delete vs. update logic was strictly intertwined, as well as the branching of slack vs. not slack.