### PR TITLE
Add Sage IP Whitelist to floating ip reaper

### DIFF
--- a/hammers/query.py
+++ b/hammers/query.py
@@ -240,7 +240,9 @@ def idle_not_reserved_floating_ips(db, threshold_days):
     NOTE: For Rocky version only!
     '''
     sql = '''
-    SELECT f.project_id AS project_id, f.id AS floating_ip_id
+    SELECT f.project_id AS project_id
+         , f.id AS floating_ip_id
+         , f.floating_ip_address AS floating_ip_address
     FROM neutron.floatingips AS f
     JOIN neutron.standardattributes AS s
     ON f.standard_attr_id = s.id

--- a/hammers/scripts/floatingip_reaper.py
+++ b/hammers/scripts/floatingip_reaper.py
@@ -24,12 +24,23 @@ from hammers import MySqlArgs, osapi, osrest, query
 from hammers.slack import Slackbot
 from hammers.util import base_parser
 
+SAGE_UC_IP_WHITELIST = [
+    '192.5.87.32',
+    '192.5.87.59',
+    '192.5.87.77',
+    '192.5.87.136',
+    '192.5.87.164'
+]
+
 def reaper(db, auth, grace_days, whitelist, dryrun=False):
     to_delete = {}
     # iterate through all idle floating ips
     for obj in query.idle_not_reserved_floating_ips(db, grace_days):
         project_id = obj['project_id']
         floating_ip_id = obj['floating_ip_id']
+
+        if obj['floating_ip_address'] in SAGE_UC_IP_WHITELIST:
+            continue
 
         # collect floating ips that don't belong to whitelist project
         if project_id not in whitelist:


### PR DESCRIPTION
The Sage project will use 5 floating ips on Chameleon for connecting to Sage
Blade devices containing edge accelerators. This is a temporary white list
that can be removed in the future as CHI@EDGE service makes progress.