### PR TITLE
fix email missing username and reservation usage notification not run

### DIFF
--- a/hammers/scripts/unutilized_lease_reaper.py
+++ b/hammers/scripts/unutilized_lease_reaper.py
@@ -102,7 +102,8 @@ def send_notification(auth, lease, sender, warn_period, termination_period,
     user = keystone.user(auth, lease['user_id'])
     html = _email.render_template(
         email_body,
-        vars=dict(lease_name=lease['name'],
+        vars=dict(username = user['name'],
+                  lease_name=lease['name'],
                   lease_id=lease['id'],
                   warn_period=warn_period,
                   termination_period=termination_period))

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
             'ironic-error-resetter = hammers.scripts.ironic_error_resetter:main',
             'orphan-resource-providers = hammers.scripts.orphan_resource_providers:main',
             'undead-instances = hammers.scripts.undead_instances:main',
-            'reservation-usage-notification = hammers.script.reservation_usage_notification',
+            'reservation-usage-notification = hammers.scripts.reservation_usage_notification',
             'orphans-detector = hammers.scripts.orphans_detector:main',
             'clean-old-aggregates = hammers.scripts.clean_old_aggregates:main',
             'floatingip-reaper = hammers.scripts.floatingip_reaper:main',


### PR DESCRIPTION
1) The username is not displayed in the unutilized reaper emails, because
the username is not passed to the email template.
2) The reservation usage notification is failed to run, because of the
error "No module named 'hammers.script"