### PR TITLE
Add check for reservations in clean-old-aggregates

### DIFF
--- a/hammers/scripts/clean_old_aggregates.py
+++ b/hammers/scripts/clean_old_aggregates.py
@@ -111,7 +111,7 @@ def has_active_allocation(orph):
         alloc for alloc in host_allocs
         if alloc['resource_id'] == orph
     ]
-    if not matching_allocs:
+    if not matching_allocs or not matching_allocs[0]['reservations']:
         return False
     res = matching_allocs[0]['reservations'][0]['id']
     return res


### PR DESCRIPTION
Previously, the following error occured:
```
Traceback (most recent call last):
 File "/usr/local/lib/python3.9/site-packages/hammers-0.3.1-py3.9.egg/hammers/scripts/clean_old_aggregates.py", line 139, in main
   destiny = has_active_allocation(orphan)
 File "/usr/local/lib/python3.9/site-packages/hammers-0.3.1-py3.9.egg/hammers/scripts/clean_old_aggregates.py", line 116, in has_active_allocation
   res = matching_allocs[0]['reservations'][0]['id']
IndexError: list index out of range
```
This check prevents this error.