### PR TITLE
fix imports, use collections.abc

### DIFF
--- a/ccmanage/ssh.py
+++ b/ccmanage/ssh.py
@@ -1,6 +1,7 @@
 
 
-import collections
+from collections.abc import Callable
+from collections import Counter
 import errno
 import os
 import socket
@@ -42,13 +43,13 @@ def dotdotdot(*args, **kwargs):
 def wait(host, username, callback='dots'):
     # error_counts = {exc_type: 0 for exc_type in expected_wait_errors}
     # sub_errors = 0
-    error_counts = collections.Counter()
+    error_counts = Counter()
     if callback == 'dots':
         callback = dotdotdot
     elif callback is None:
         callback = _nothing
     else:
-        if not isinstance(callback, collections.Callable):
+        if not isinstance(callback, Callable):
             raise ValueError("callback isn't callable.")
 
     key_filename = fapi.env.key_filename

--- a/hammers/osrest/neutron.py
+++ b/hammers/osrest/neutron.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 
 from hammers.osrest.base import BaseAPI
 
@@ -8,7 +8,7 @@ API = BaseAPI('network')
 
 def floatingip_delete(auth, floatingip):
     """Frees a floating IP by ID"""
-    if isinstance(floatingip, collections.Mapping):
+    if isinstance(floatingip, Mapping):
         floatingip = floatingip['id']
 
     response = API.delete(auth, '/v2.0/floatingips/{}'.format(floatingip))
@@ -26,7 +26,7 @@ def floatingips(auth):
 
 def network(auth, net):
     """Gets a network by ID, or mapping containing an ``'id'`` key."""
-    if isinstance(net, collections.Mapping):
+    if isinstance(net, Mapping):
         net = net['id']
 
     response = API.get(auth, '/v2.0/networks/{}'.format(net))
@@ -43,7 +43,7 @@ def networks(auth):
 
 def port_delete(auth, port):
     """Deletes a port by ID, or mapping containing an ``'id'`` key."""
-    if isinstance(port, collections.Mapping):
+    if isinstance(port, Mapping):
         port = port['id']
 
     response = API.delete(auth,  '/v2.0/ports/{}'.format(port))
@@ -61,7 +61,7 @@ def ports(auth):
 
 def subnet(auth, subnet):
     """Get subnet info. Accepts ID or mapping containing an ``'id'`` key."""
-    if isinstance(subnet, collections.Mapping):
+    if isinstance(subnet, Mapping):
         subnet = subnet['id']
 
     response = API.get(auth, '/v2.0/subnets/{}'.format(subnet))

--- a/hammers/scripts/conflict_macs.py
+++ b/hammers/scripts/conflict_macs.py
@@ -12,7 +12,7 @@ config---otherwise the script would think that they are in conflict.
 '''
 
 
-import collections
+from collections import Counter
 import configparser
 import json
 import os
@@ -130,7 +130,7 @@ def find_conflicts(auth, ignore_subnets):
         mac_collisions = [
             (mac, count)
             for mac, count
-            in collections.Counter(macs).items()
+            in Counter(macs).items()
             if count > 1
         ]
         message_lines = []

--- a/hammers/scripts/dirty_ports.py
+++ b/hammers/scripts/dirty_ports.py
@@ -15,7 +15,7 @@ ports on nodes that are in the "available" state.
 
 import sys
 import os
-import collections
+from collections import defaultdict
 # import datetime
 # from pprint import pprint
 
@@ -28,7 +28,7 @@ from hammers.util import base_parser
 OS_ENV_PREFIX = 'OS_'
 
 def ports_by_node(ports, assert_single=False):
-    node_ports = collections.defaultdict(list)
+    node_ports = defaultdict(list)
     for port_id, port in ports.items():
         node_ports[port['node_uuid']].append(port)
     node_ports.default_factory = None

--- a/hammers/scripts/lease_stack_reaper.py
+++ b/hammers/scripts/lease_stack_reaper.py
@@ -8,7 +8,7 @@ Reclaims nodes from leases that violate terms of use.
 
 * ``info`` to just display leases or actuall delete them with ``delete``
 '''
-import collections
+from collections import defaultdict
 import sys
 from pprint import pprint
 from datetime import datetime
@@ -34,7 +34,7 @@ EXCLUDED_PROJECT_IDS = [
     '22521dca92d042f3b98c30bf02c50491',  ## SCC21 CHI-210869
     '5e979a2c26844f2aa62f1342205cd79b',  ## SCC21 CHI-210870
     'b23da57cc66f4ea9add421e635a293a2',  ## SCC21 CHI-210878
-] 
+]
 EXCLUDED_NODE_TYPES = [
     'compute_skylake'
 ]
@@ -48,7 +48,7 @@ class User:
         self.user_id = user_id
         self.name = name
         self.email = email
-        self.nodes = collections.defaultdict(list)
+        self.nodes = defaultdict(list)
 
     def add_lease(self, node_type, lease):
         """Add lease to node list."""
@@ -68,7 +68,7 @@ class User:
         for node_type, leases in self.nodes.items():
             if node_type in EXCLUDED_NODE_TYPES:
                 continue
-            
+
             if 'gpu_' in node_type:
                 gpu_day_violation = self.find_gpu_days_limit_leases(leases)
                 leases_to_delete.update(gpu_day_violation)
@@ -156,7 +156,7 @@ def collect_user_leases(auth):
     users = {}
     users_by_id = keystone.users(auth)
     hosts_by_id = blazar.hosts(auth)
-    allocs_by_lease = collections.defaultdict(list)
+    allocs_by_lease = defaultdict(list)
 
     for alloc in blazar.host_allocations(auth):
         for r in alloc['reservations']:

--- a/hammers/scripts/metadata_sync.py
+++ b/hammers/scripts/metadata_sync.py
@@ -4,7 +4,7 @@ Synchronizes the metadata contained in the G5K API to Blazar's "extra
 capabilities". Keys not in Blazar are created, those not in G5K are deleted.
 """
 
-import collections
+from collections.abc import Mapping, Iterable, Sequence
 import sys
 
 import requests
@@ -53,7 +53,7 @@ def ignore_keys(keys, prefixes):
 
 
 def nonstringiterable(arg):
-    return (isinstance(arg, collections.Iterable)
+    return (isinstance(arg, Iterable)
             and not isinstance(arg, six.string_types))
 
 
@@ -62,9 +62,9 @@ def _flatten_to_dots(obj, prefix=None):
         prefix = []
 
     if nonstringiterable(obj):
-        if isinstance(obj, collections.Sequence): # list-like, integer keys
+        if isinstance(obj, Sequence): # list-like, integer keys
             items = enumerate(obj)
-        elif isinstance(obj, collections.Mapping): # dict-like, string keys
+        elif isinstance(obj, Mapping): # dict-like, string keys
             items = list(obj.items())
         else:
             raise RuntimeError('unhandlable type')


### PR DESCRIPTION
Mapping, and other abstract base-classes have been moved from
`collections` to `collections.abc`. Fix imports to match.