### PR TITLE
lease starting after 21 days - Fix false positive

### DIFF
--- a/hammers/scripts/lease_stack_notifier.py
+++ b/hammers/scripts/lease_stack_notifier.py
@@ -134,7 +134,6 @@ class Project:
         self.furthest_end_date_by_node_type = defaultdict(
             lambda: DATETIME_NOW + self.minimum_lease_window
         )
-        self.start_date_by_host = defaultdict(lambda: DATETIME_NOW)
         self.start_date_by_node_type = defaultdict(lambda: datetime.max)
 
     def __str__(self):
@@ -206,6 +205,9 @@ class Project:
                 self.furthest_end_date_by_node_type[node_type]
                 - self.start_date_by_node_type[node_type]
             ).total_seconds()
+            # if coverage period is less then minimum window days - skip
+            if seconds_in_coverage_period < self.minimum_lease_window.total_seconds():
+                continue
             coverage_percentage = seconds_covered / seconds_in_coverage_period
 
             if coverage_percentage >= lease_coverage_threshold:

--- a/hammers/scripts/tests/test_lease_notifier.py
+++ b/hammers/scripts/tests/test_lease_notifier.py
@@ -406,6 +406,52 @@ class TestLeaseComplianceManager(unittest.TestCase):
             }
         )
 
+    def test_lease_starting_late(self):
+        leases = [
+            create_lease('lease1', 50, 57),
+            create_lease('lease2', 57, 64),
+            create_lease('lease3', 64, 71),
+        ]
+        allocations = [{
+            'resource_id': 'host1',
+            'reservations': [
+                {'lease_id': 'lease1'},
+            ]
+        }, {
+            'resource_id': 'host1',
+            'reservations': [
+                {'lease_id': 'lease2'},
+            ]
+        }, {
+            'resource_id': 'host1',
+            'reservations': [
+                {'lease_id': 'lease3'},
+            ]
+        },{
+            'resource_id': 'host1',
+            'reservations': [
+                {'lease_id': 'lease4'},
+            ]
+        }]
+        self.run_test_scenario(
+            leases,
+            'project1',
+            allocations,
+            expected_violations={
+                'compute_skylake': {'coverage_percentage': 1.0}
+            }
+        )
+        leases = [
+            create_lease('lease1', 50, 57),
+            create_lease('lease2', 57, 64),
+        ]
+        self.run_test_scenario(
+            leases,
+            'project1',
+            allocations,
+            expected_violations={}
+        )
+
     def test_lease_duration_violation_late_start(self):
         leases = [
             create_lease('lease2', 7, 14),


### PR DESCRIPTION
Fixed an issue where false lease stacking notifications were being triggered when the lease was starting beyond 21 days from current date.

21 days from current date means, the value of `furthest_end_date_by_node_type` (Considered as end of coverage period) will be the last (furthest end date) project's particular node_type's lease `end_date`

These false positive notifications have coverage end as lease end as furthest lease's end date and coverage start as latest lease start date. This is causing the lease stacking notifier to trigger a notification as the coverage percentage is 100%.

The fix involved skipping the check for coverage percentage calculation if the coverage period is less than the minimum window days (21 days by defult).

Added a test case to ensure the correct behavior of the fix.